### PR TITLE
adding summary pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM mambaorg/micromamba:1.4.2-bullseye
+
+# We want all RUN commands to use Bash.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Copy over your environment file
+COPY environment.yml /tmp/environment.yml
+
+# Create the environment
+RUN micromamba create -n geopy311 -f /tmp/environment.yml --yes && \
+    micromamba clean --all --yes
+
+ARG WORKDIR=/usr/local/esos_c_models
+ENV WORKDIR=${WORKDIR}
+
+RUN micromamba shell init -s bash -p /opt/conda
+
+# If needed, ensure the file exists and append your activation line
+RUN touch /home/mambauser/.bashrc
+RUN echo 'micromamba activate geopy311' >> /home/mambauser/.bashrc
+
+USER root
+RUN apt-get update -y
+RUN apt install git -y
+RUN apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    make \
+    build-essential \
+    zlib1g-dev \
+    libpython3-dev \
+    libssl-dev \
+    libffi-dev \
+    libsqlite3-dev \
+    libgdal-dev
+
+ARG CACHEBUST=1
+
+RUN git clone https://github.com/springinnovate/ecoshard.git /usr/local/ecoshard && \
+    cd /usr/local/ecoshard && \
+    micromamba run -n geopy311 pip install . --no-build-isolation && \
+    git log -1 --format="%h on %ci" > /usr/local/ecoshard.gitversion
+
+# This shows the timedate of the ecoshard and inspring repos
+RUN echo 'if [ -f "/usr/local/ecoshard.gitversion" ]; then' >> /home/mambauser/.bashrc && \
+    echo '  echo "ecoshard: commit on $(cat /usr/local/ecoshard.gitversion)"' >> /home/mambauser/.bashrc && \
+    echo 'fi' >> /home/mambauser/.bashrc
+
+USER mambauser
+WORKDIR ${WORKDIR}
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ COPY environment.yml /tmp/environment.yml
 RUN micromamba create -n geopy311 -f /tmp/environment.yml --yes && \
     micromamba clean --all --yes
 
-ARG WORKDIR=/usr/local/esos_c_models
-ENV WORKDIR=${WORKDIR}
-
 RUN micromamba shell init -s bash -p /opt/conda
 
 # If needed, ensure the file exists and append your activation line
@@ -47,5 +44,5 @@ RUN echo 'if [ -f "/usr/local/ecoshard.gitversion" ]; then' >> /home/mambauser/.
     echo 'fi' >> /home/mambauser/.bashrc
 
 USER mambauser
-WORKDIR ${WORKDIR}
+WORKDIR /workspace
 CMD ["/bin/bash"]

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+name: geopy311
+channels:
+  - conda-forge
+dependencies:
+  - gdal=3.10.3
+  - geopandas
+  - rtree=1.4.0
+  - scipy=1.15.2
+  - shapely=2.1.0
+  - numpy=2.2.5
+  - numexpr=2.10.2
+  - psutil=7.0.0
+  - cython=3.0.11

--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,5 @@ dependencies:
   - numexpr=2.10.2
   - psutil=7.0.0
   - cython=3.0.11
+  - exactextract=0.2.2
+  - retrying=1.3.4

--- a/summary_pipeline.py
+++ b/summary_pipeline.py
@@ -1,4 +1,4 @@
-"""Summarize reference data across dynamic data."""
+"""Summarize analysis raster data across reference vector data."""
 
 from pathlib import Path
 from datetime import datetime
@@ -11,9 +11,6 @@ from geopandas import gpd
 from exactextract import exact_extract
 import psutil
 from ecoshard import taskgraph
-from tqdm import tqdm
-import pandas as pd
-import subprocess
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -26,6 +23,7 @@ logging.basicConfig(
 
 LOGGER = logging.getLogger(__name__)
 logging.getLogger("ecoshard.taskgraph").setLevel(logging.INFO)
+
 REFERENCE_SUMMARY_VECTOR_PATHS = {
     "hydrosheds_lv6_synth": "./data/reference/hydrosheds_lv6_synth.gpkg"
 }
@@ -35,56 +33,33 @@ ANALYSIS_DATA = {
     (
         "GHS_BUILT_S_E2020_GLOBE_R2023A_4326_3ss_V1_0",
         2020,
-    ): "./data/analysis/GHS_BUILT_S_E2020_GLOBE_R2023A_4326_3ss_V1_0_clip.tif",
+    ): "./data/analysis/GHS_BUILT_S_E2020_GLOBE_R2023A_4326_3ss_V1_0.tif",
     (
         "GHS_BUILT_S_E1990_GLOBE_R2023A_4326_3ss_V1_0",
         1990,
-    ): "./data/analysis/GHS_BUILT_S_E1990_GLOBE_R2023A_4326_3ss_V1_0_clip.tif",
+    ): "./data/analysis/GHS_BUILT_S_E1990_GLOBE_R2023A_4326_3ss_V1_0.tif",
     (
         "GHS_BUILT_S_E1995_GLOBE_R2023A_4326_3ss_V1_0",
         1995,
-    ): "./data/analysis/GHS_BUILT_S_E1995_GLOBE_R2023A_4326_3ss_V1_0_clip.tif",
+    ): "./data/analysis/GHS_BUILT_S_E1995_GLOBE_R2023A_4326_3ss_V1_0.tif",
     (
         "GHS_BUILT_S_E2000_GLOBE_R2023A_4326_3ss_V1_0",
         2000,
-    ): "./data/analysis/GHS_BUILT_S_E2000_GLOBE_R2023A_4326_3ss_V1_0_clip.tif",
+    ): "./data/analysis/GHS_BUILT_S_E2000_GLOBE_R2023A_4326_3ss_V1_0.tif",
     (
         "GHS_BUILT_S_E2005_GLOBE_R2023A_4326_3ss_V1_0",
         2005,
-    ): "./data/analysis/GHS_BUILT_S_E2005_GLOBE_R2023A_4326_3ss_V1_0_clip.tif",
+    ): "./data/analysis/GHS_BUILT_S_E2005_GLOBE_R2023A_4326_3ss_V1_0.tif",
     (
         "GHS_BUILT_S_E2010_GLOBE_R2023A_4326_3ss_V1_0",
         2010,
-    ): "./data/analysis/GHS_BUILT_S_E2010_GLOBE_R2023A_4326_3ss_V1_0_clip.tif",
+    ): "./data/analysis/GHS_BUILT_S_E2010_GLOBE_R2023A_4326_3ss_V1_0.tif",
     (
         "GHS_BUILT_S_E2015_GLOBE_R2023A_4326_3ss_V1_0",
         2015,
-    ): "./data/analysis/GHS_BUILT_S_E2015_GLOBE_R2023A_4326_3ss_V1_0_clip.tif",
+    ): "./data/analysis/GHS_BUILT_S_E2015_GLOBE_R2023A_4326_3ss_V1_0.tif",
 }
 
-bbox = [-86, 31, -80, 34]  # minx, miny, maxx, maxy in lon/lat
-
-# for key, in_path in ANALYSIS_DATA.items():
-#     in_path = Path(in_path)
-#     out_path = in_path.with_name(f"{in_path.stem}_clip.tif")
-#     subprocess.run(
-#         [
-#             "gdalwarp",
-#             "-te",
-#             *map(str, bbox),
-#             "-overwrite",
-#             "-co",
-#             "TILED=YES",
-#             "-co",
-#             "COMPRESS=DEFLATE",
-#             str(in_path),
-#             str(out_path),
-#         ],
-#         check=True,
-#     )
-#     ANALYSIS_DATA[key] = str(out_path)
-#     print(f"clipped {out_path}")
-# sys.exit()
 
 WORKSPACE_DIR = "./summary_pipeline_workspace"
 os.makedirs(WORKSPACE_DIR, exist_ok=True)
@@ -92,13 +67,30 @@ REPORTING_INTERVAL = 10.0
 ZONAL_OPS = ["mean", "max", "min"]
 
 
-def create_progress_logger(UPDATE_RATE, task_id):
+def create_progress_logger(update_rate, task_id):
+    """Create a logging function to report progress of a long-running task.
+
+    This function returns a nested logger function that logs the progress of
+    a task based on a specified update interval. Each logged message includes
+    the task identifier, the completion percentage, and the elapsed time since
+    the task started.
+
+    Args:
+        update_rate (float): Minimum time interval (in seconds) between
+            consecutive log updates.
+        task_id (str): Identifier for the task, included in each log message.
+
+    Returns:
+        callable: A logger function that accepts two arguments:
+            fraction (float): Progress of the task as a float between 0 and 1.
+            message (str): Additional message describing the current task state.
+    """
     start_time = time.time()
     last_time = start_time
 
     def _process_logger(fraction, message):
         nonlocal last_time
-        if time.time() - last_time > UPDATE_RATE:
+        if time.time() - last_time > update_rate:
             LOGGER.info(
                 f"{task_id} is {100*fraction:.2f}% complete running for "
                 f"{time.time()-start_time:.2f}s"
@@ -109,6 +101,24 @@ def create_progress_logger(UPDATE_RATE, task_id):
 
 
 def zonal_stats(raster_path, vector_path):
+    """Calculate zonal statistics for vector file over a given raster.
+
+    This function reads polygon geometries from a vector file, assigns a
+    unique identifier (FID) to each geometry, and computes zonal statistics
+    such as mean, sum, count, min, and max of the raster values intersecting
+    each polygon. Statistics calculation uses exact extraction methods,
+    ensuring accuracy particularly at polygon boundaries.
+
+    Args:
+        raster_path (str): Path to the input raster file.
+        vector_path (str): Path to the vector file containing polygon
+            geometries.
+
+    Returns:
+        pandas.DataFrame: DataFrame containing zonal statistics with one row
+        per polygon, identified by 'fid' and columns for each calculated
+        statistic named from `ZONAL_OPS`.
+    """
     gdf = gpd.read_file(vector_path)
 
     # need to get the FID column in there so we can join results
@@ -123,7 +133,6 @@ def zonal_stats(raster_path, vector_path):
         include_cols=["fid"],
         output="pandas",
         strategy="raster-sequential",
-        # max_cells_in_memory=30000000 * 4,
         progress=create_progress_logger(REPORTING_INTERVAL, stem),
     )
     return stats_df
@@ -148,7 +157,10 @@ def main():
                 task_name=f"zonal stats for {raster_id} on {vector_id}",
             )
             zonal_stats_task_list.append((raster_id, stats_task))
+
+        # process zonal results
         gdf = gpd.read_file(vector_path)
+
         # need to get the FID column in there so we can join results
         gdf = gdf[["geometry"]].copy()
         gdf["fid"] = gdf.index.astype("int32")
@@ -158,7 +170,9 @@ def main():
             stats_df.rename(columns=rename_map, inplace=True)
             gdf = gdf.merge(stats_task.get(), on="fid")
         timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-        out_vector_path = f"{vector_id}_synth_zonal_{timestamp}.gpkg"
+        out_vector_path = os.path.join(
+            WORKSPACE_DIR, f"{vector_id}_synth_zonal_{timestamp}.gpkg"
+        )
         gdf.to_file(out_vector_path, driver="GPKG")
         print(f"output written to {out_vector_path}")
 

--- a/summary_pipeline.py
+++ b/summary_pipeline.py
@@ -140,6 +140,7 @@ def zonal_stats(raster_path, vector_path):
 
 def main():
     """Entry point."""
+    start_time = time.time()
     physical_cores = psutil.cpu_count(logical=False)
     task_graph = taskgraph.TaskGraph(
         WORKSPACE_DIR,
@@ -174,7 +175,7 @@ def main():
             WORKSPACE_DIR, f"{vector_id}_synth_zonal_{timestamp}.gpkg"
         )
         gdf.to_file(out_vector_path, driver="GPKG")
-        print(f"output written to {out_vector_path}")
+        print(f"done in {start_time:.2f}s, output written to {out_vector_path}")
 
 
 if __name__ == "__main__":

--- a/summary_pipeline.py
+++ b/summary_pipeline.py
@@ -5,6 +5,7 @@ import os
 import sys
 from datetime import datetime
 
+import psutil
 from ecoshard.geoprocessing import zonal_statistics
 from ecoshard import taskgraph
 from tqdm import tqdm
@@ -70,8 +71,9 @@ os.makedirs(WORKSPACE_DIR, exist_ok=True)
 
 def main():
     """Entry point."""
+    physical_cores = psutil.cpu_count(logical=False)
     task_graph = taskgraph.TaskGraph(
-        WORKSPACE_DIR, n_workers=-1, reporting_interval=15.0
+        WORKSPACE_DIR, n_workers=physical_cores, reporting_interval=15.0
     )
     zonal_stats_task_list = []
     for (description, year), raster_path in ANALYSIS_DATA.items():

--- a/summary_pipeline.py
+++ b/summary_pipeline.py
@@ -1,0 +1,123 @@
+"""Summarize reference data across dynamic data."""
+
+import logging
+import os
+import sys
+from datetime import datetime
+
+from ecoshard.geoprocessing import zonal_statistics
+from ecoshard import taskgraph
+from tqdm import tqdm
+import pandas as pd
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    stream=sys.stdout,
+    format=(
+        "%(asctime)s (%(relativeCreated)d) %(levelname)s %(name)s"
+        " [%(funcName)s:%(lineno)d] %(message)s"
+    ),
+)
+
+REFERENCE_SUMMARY_VECTOR_PATHS = {
+    "hydrosheds_lv6_synth": "./data/reference/hydrosheds_lv6_synth.gpkg"
+}
+
+# Tag format is a tuple ([description], [YYYY])
+REFERNCE_LANDCOVER_RASTER_PATHS = {
+    "landcover_gl_1995": "./data/reference/landcover_gl_1995.tif",
+    "landcover_gl_1992": "./data/reference/landcover_gl_1992.tif",
+}
+
+# Tag format is a tuple ([description], [YYYY])
+ANALYSIS_DATA = {
+    (
+        "GHS_BUILT_S_E2020_GLOBE_R2023A_4326_3ss_V1_0",
+        2020,
+    ): "./data/analysis/GHS_BUILT_S_E2020_GLOBE_R2023A_4326_3ss_V1_0.tif",
+    (
+        "GHS_BUILT_S_E1990_GLOBE_R2023A_4326_3ss_V1_0",
+        1990,
+    ): "./data/analysis/GHS_BUILT_S_E1990_GLOBE_R2023A_4326_3ss_V1_0.tif",
+    (
+        "GHS_BUILT_S_E1995_GLOBE_R2023A_4326_3ss_V1_0",
+        1995,
+    ): "./data/analysis/GHS_BUILT_S_E1995_GLOBE_R2023A_4326_3ss_V1_0.tif",
+    (
+        "GHS_BUILT_S_E2000_GLOBE_R2023A_4326_3ss_V1_0",
+        2000,
+    ): "./data/analysis/GHS_BUILT_S_E2000_GLOBE_R2023A_4326_3ss_V1_0.tif",
+    (
+        "GHS_BUILT_S_E2005_GLOBE_R2023A_4326_3ss_V1_0",
+        2005,
+    ): "./data/analysis/GHS_BUILT_S_E2005_GLOBE_R2023A_4326_3ss_V1_0.tif",
+    (
+        "GHS_BUILT_S_E2010_GLOBE_R2023A_4326_3ss_V1_0",
+        2010,
+    ): "./data/analysis/GHS_BUILT_S_E2010_GLOBE_R2023A_4326_3ss_V1_0.tif",
+    (
+        "GHS_BUILT_S_E2015_GLOBE_R2023A_4326_3ss_V1_0",
+        2015,
+    ): "./data/analysis/GHS_BUILT_S_E2015_GLOBE_R2023A_4326_3ss_V1_0.tif",
+}
+
+# percent change of any ecosystem service
+# don't look at landcover change
+
+WORKSPACE_DIR = "./summary_pipeline_workspace"
+os.makedirs(WORKSPACE_DIR, exist_ok=True)
+
+
+def main():
+    """Entry point."""
+    task_graph = taskgraph.TaskGraph(
+        WORKSPACE_DIR, n_workers=-1, reporting_interval=15.0
+    )
+    zonal_stats_task_list = []
+    for (description, year), raster_path in ANALYSIS_DATA.items():
+        zonal_stats_task = task_graph.add_task(
+            func=zonal_statistics,
+            args=(
+                (raster_path, 1),
+                REFERENCE_SUMMARY_VECTOR_PATHS["hydrosheds_lv6_synth"],
+            ),
+            kwargs={
+                "polygons_might_overlap": False,
+                "working_dir": WORKSPACE_DIR,
+            },
+            store_result=True,
+            task_name=f"stats for {description}",
+        )
+        zonal_stats_task_list.append((description, year, zonal_stats_task))
+    task_graph.join()
+    row_list = []
+    for description, year, zonal_task in tqdm(zonal_stats_task_list):
+        zonal_stats = zonal_task.get()
+        for fid, stats in zonal_stats.items():
+            # mean approximated by dividing by number of valid pixels
+            mean_value = (
+                stats["sum"] / stats["count"] if stats["count"] > 0 else None
+            )
+
+            row_list.append(
+                {
+                    "raster id": description,
+                    "year": year,
+                    "fid": fid,
+                    "min": stats["min"],
+                    "max": stats["max"],
+                    "sum": stats["sum"],
+                    "count": stats["count"],
+                    "nodata_count": stats["nodata_count"],
+                    "mean": mean_value,
+                }
+            )
+
+    df = pd.DataFrame(row_list)
+    timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    filename = f"zonal_stats_{timestamp}.csv"
+    df.to_csv(filename, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/summary_pipeline.py
+++ b/summary_pipeline.py
@@ -133,6 +133,9 @@ def zonal_stats(raster_path, vector_path):
         include_cols=["fid"],
         output="pandas",
         strategy="raster-sequential",
+        # i found a *2 and *4 to make a nearly twofold improvment, but didn't
+        # see gains at *8
+        max_cells_in_memory=30000000 * 4,
         progress=create_progress_logger(REPORTING_INTERVAL, stem),
     )
     return stats_df

--- a/summary_pipeline.py
+++ b/summary_pipeline.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from datetime import datetime
+from datetime import timedelta
 import time
 import logging
 import os
@@ -91,9 +92,13 @@ def create_progress_logger(update_rate, task_id):
     def _process_logger(fraction, message):
         nonlocal last_time
         if time.time() - last_time > update_rate:
+            elapsed_time = time.time() - start_time
+            estimated_time_remaining = elapsed_time / fraction - elapsed_time
+            elapsed_str = str(timedelta(seconds=int(elapsed_time)))
+            etc_str = str(timedelta(seconds=int(estimated_time_remaining)))
             LOGGER.info(
                 f"{task_id} is {100*fraction:.2f}% complete running for "
-                f"{time.time()-start_time:.2f}s"
+                f"{elapsed_str}, estimate {etc_str} remaining"
             )
             last_time = time.time()
 


### PR DESCRIPTION
This PR adds a `summary_pipeline.py` function that in parallel calculates zonal stats for over any number of vectors over any number of polygons. It also includes a docker computational environment that can be used to run this pipeline.

Usage:
* look at `summary_pipeline.py` and note the `ANALYSIS_DATA` and `REFERENCE_SUMMARY_VECTOR_PATHS`, and `ZONAL_OPS` data structures at the top of `summary_pipeline.py`. These define the reference vectors, analysis rasters, and summary operations respectively. If this was a real-world pipeline we'd abstract those to a .yaml or CSV I think, but this works too.
* To execute, you must have the most recent `ecosharding` and other libraries mentioned in `environment.yml` installed. I've built this into a docker container described by `Dockerfile` that is already built and pushed to dockerhub. You can run it yourself with this command: `docker pull therealspring/global_ncp-computational-environment:latest && docker run -it --rm -v `pwd`:/workspace therealspring/global_ncp-computational-environment:latest /bin/bash`. (for Windows run like this `docker pull therealspring/global_ncp-computational-environment:latest && docker run -it --rm -v %CD%:/workspace therealspring/global_ncp-computational-environment:latest /bin/bash`.)
* Running the above will drop you into the docker container shell at /workspace which mirrors the current working directory of which you ran the container. If you ran it in the root of this repository you can directly run `python summary_pipeline.py` and let it rip.

Approach
* This pipeline uses `taskgraph` to execute in parallel zonal statistics on any combination of vectors or rasters; one worker per vector/raster combination. It also caches the results of previous vector/raster runs, so repeated calls to this pipeline will return immediate results. In practice it will spin up as many workers of either the minimum of the number of raster/vector pairs to process or the physical cores on the workstation.
* Each call uses the `exactextract` library to do high performance zonal stats with the summary functions defined in `ZONAL_OPS`. The available operations can be found here: https://isciences.github.io/exactextract/operations.html 
* Each call calculates these summary statistics for an entire vector over the raster and they are all aggregated to create one output vector geopackage per `REFERENCE_SUMMARY_VECTOR_PATHS` item.

