### PR TITLE
Feature/6 add yaml config input

### DIFF
--- a/analysis_configs/example_gdp_huc6_analysis.yaml
+++ b/analysis_configs/example_gdp_huc6_analysis.yaml
@@ -1,0 +1,42 @@
+# Example config file for the globalNCP summary pipeline
+
+workspace_dir:
+  path: "./summary_pipeline_workspace"
+
+vector_zones:
+  hydrosheds_lv6_synth: 
+    path: "./data/reference/hydrosheds_lv6_synth.gpkg"
+
+raster_layers:
+  rast_gdpTot_1990_2020_30arcsec_1990:
+    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+    band: 1
+
+  rast_gdpTot_1990_2020_30arcsec_1995:
+    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+    band: 2
+
+  rast_gdpTot_1990_2020_30arcsec_2000:
+    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+    band: 3
+
+  rast_gdpTot_1990_2020_30arcsec_2005:
+    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+    band: 4
+
+  rast_gdpTot_1990_2020_30arcsec_2010:
+    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+    band: 5
+
+  rast_gdpTot_1990_2020_30arcsec_2015:
+    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+    band: 6
+
+  rast_gdpTot_1990_2020_30arcsec_2020:
+    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+    band: 7
+
+ops_stats:
+  - mean
+  - max
+  - min

--- a/analysis_configs/example_gdp_huc6_analysis.yaml
+++ b/analysis_configs/example_gdp_huc6_analysis.yaml
@@ -5,38 +5,14 @@ workspace_dir:
 
 vector_zones:
   hydrosheds_lv6_synth: 
-    path: "./data/reference/hydrosheds_lv6_synth.gpkg"
+    path: "../data/reference/hydrosheds_lv6_synth.gpkg"
 
 raster_layers:
   test_rast_gdpTot_1990_2020_30arcsec_1990:
-    path: "./data/test_clip.tif"
+    path: "../data/test_clip.tif"
     band: 1
 
-  test_rast_gdpTot_1990_2020_30arcsec_1995:
-    path: "./data/test_clip.tif"
-    band: 2
-
-  test_rast_gdpTot_1990_2020_30arcsec_2000:
-    path: "./data/test_clip.tif"
-    band: 3
-
-  test_rast_gdpTot_1990_2020_30arcsec_2005:
-    path: "./data/test_clip.tif"
-    band: 4
-
-  test_rast_gdpTot_1990_2020_30arcsec_2010:
-    path: "./data/test_clip.tif"
-    band: 5
-
-  test_rast_gdpTot_1990_2020_30arcsec_2015:
-    path: "./data/test_clip.tif"
-    band: 6
-
-  test_rast_gdpTot_1990_2020_30arcsec_2020:
-    path: "./data/test_clip.tif"
-    band: 7
-
-ops_stats:
+op_stats:
   - mean
   - max
   - min

--- a/analysis_configs/example_gdp_huc6_analysis.yaml
+++ b/analysis_configs/example_gdp_huc6_analysis.yaml
@@ -8,32 +8,32 @@ vector_zones:
     path: "./data/reference/hydrosheds_lv6_synth.gpkg"
 
 raster_layers:
-  rast_gdpTot_1990_2020_30arcsec_1990:
-    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+  test_rast_gdpTot_1990_2020_30arcsec_1990:
+    path: "./data/test_clip.tif"
     band: 1
 
-  rast_gdpTot_1990_2020_30arcsec_1995:
-    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+  test_rast_gdpTot_1990_2020_30arcsec_1995:
+    path: "./data/test_clip.tif"
     band: 2
 
-  rast_gdpTot_1990_2020_30arcsec_2000:
-    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+  test_rast_gdpTot_1990_2020_30arcsec_2000:
+    path: "./data/test_clip.tif"
     band: 3
 
-  rast_gdpTot_1990_2020_30arcsec_2005:
-    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+  test_rast_gdpTot_1990_2020_30arcsec_2005:
+    path: "./data/test_clip.tif"
     band: 4
 
-  rast_gdpTot_1990_2020_30arcsec_2010:
-    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+  test_rast_gdpTot_1990_2020_30arcsec_2010:
+    path: "./data/test_clip.tif"
     band: 5
 
-  rast_gdpTot_1990_2020_30arcsec_2015:
-    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+  test_rast_gdpTot_1990_2020_30arcsec_2015:
+    path: "./data/test_clip.tif"
     band: 6
 
-  rast_gdpTot_1990_2020_30arcsec_2020:
-    path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+  test_rast_gdpTot_1990_2020_30arcsec_2020:
+    path: "./data/test_clip.tif"
     band: 7
 
 ops_stats:

--- a/environment.yml
+++ b/environment.yml
@@ -2,14 +2,15 @@ name: geopy311
 channels:
   - conda-forge
 dependencies:
+  - cython=3.0.11
+  - exactextract=0.2.2
   - gdal=3.10.3
   - geopandas
+  - numexpr=2.10.2
+  - numpy=2.2.5
+  - psutil=7.0.0
+  - retrying=1.3.4
   - rtree=1.4.0
   - scipy=1.15.2
   - shapely=2.1.0
-  - numpy=2.2.5
-  - numexpr=2.10.2
-  - psutil=7.0.0
-  - cython=3.0.11
-  - exactextract=0.2.2
-  - retrying=1.3.4
+  - yaml=0.2.5

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   - numexpr=2.10.2
   - numpy=2.2.5
   - psutil=7.0.0
+  - pyyaml=6.0.2
   - retrying=1.3.4
   - rtree=1.4.0
   - scipy=1.15.2
   - shapely=2.1.0
-  - yaml=0.2.5

--- a/environment.yml
+++ b/environment.yml
@@ -5,26 +5,13 @@ dependencies:
   - cython=3.0.11
   - exactextract=0.2.2
   - gdal=3.10.3
-<<<<<<< HEAD
-  - geopandas
+  - geopandas=1.0.1
   - numexpr=2.10.2
   - numpy=2.2.5
   - psutil=7.0.0
   - pyyaml=6.0.2
-  - retrying=1.3.4
-  - rtree=1.4.0
-  - scipy=1.15.2
-  - shapely=2.1.0
-=======
-  - geopandas=1.0.1
-  - rtree=1.4.0
-  - scipy=1.15.2
-  - shapely=2.1.0
-  - numpy=2.2.5
-  - numexpr=2.10.2
-  - psutil=7.0.0
-  - cython=3.0.11
-  - exactextract=0.2.2
-  - retrying=1.3.4
   - rasterio=1.4.3
->>>>>>> feature/2-add-band-id-functionality
+  - retrying=1.3.4
+  - rtree=1.4.0
+  - scipy=1.15.2
+  - shapely=2.1.0

--- a/summary_pipeline.py
+++ b/summary_pipeline.py
@@ -219,6 +219,7 @@ def main():
     zonal_stats_task_list = []
 
     vector_zones = pipeline_config["vector_zones"]
+    output_vector_list = []
     for vector_id, vector_config in vector_zones.items():
         vector_path = vector_config["path"]
         for raster_id, raster_path_band_dict in raster_layers.items():
@@ -251,11 +252,14 @@ def main():
         out_vector_path = os.path.join(
             workspace_dir, f"{vector_id}_synth_zonal_{timestamp}.gpkg"
         )
+        output_vector_list.append(out_vector_path)
         gdf.to_file(out_vector_path, driver="GPKG")
-        print(
-            f"done in {time.time()-start_time:.2f}s, output written to "
-            f"{out_vector_path}"
-        )
+    task_graph.join()
+    task_graph.close()
+    print(
+        f"done in {time.time()-start_time:.2f}s, output(s) written to "
+        + ",".join(output_vector_list)
+    )
 
 
 if __name__ == "__main__":

--- a/summary_pipeline.py
+++ b/summary_pipeline.py
@@ -1,18 +1,21 @@
 """Summarize analysis raster data across reference vector data."""
 
-from pathlib import Path
 from datetime import datetime
 from datetime import timedelta
-import time
+from pathlib import Path
+import argparse
 import logging
 import os
 import sys
+import time
+import textwrap
+import yaml
 
-from geopandas import gpd
+from ecoshard import taskgraph
 from exactextract import exact_extract
 from exactextract.raster import GDALRasterSource
+from geopandas import gpd
 import psutil
-from ecoshard import taskgraph
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -30,44 +33,38 @@ REFERENCE_SUMMARY_VECTOR_PATHS = {
     "hydrosheds_lv6_synth": "./data/reference/hydrosheds_lv6_synth.gpkg"
 }
 
-# Tag format is a tuple ([description], [YYYY]) key
-# with a "path" -> str and "band" -> int dictionary value
-ANALYSIS_DATA = {
-    ("rast_gdpTot_1990_2020_30arcsec", 1990): {
-        "path": "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif",
-        "band": 1,
-    },
-    ("rast_gdpTot_1990_2020_30arcsec", 1995): {
-        "path": "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif",
-        "band": 2,
-    },
-    ("rast_gdpTot_1990_2020_30arcsec", 2000): {
-        "path": "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif",
-        "band": 3,
-    },
-    ("rast_gdpTot_1990_2020_30arcsec", 2005): {
-        "path": "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif",
-        "band": 4,
-    },
-    ("rast_gdpTot_1990_2020_30arcsec", 2010): {
-        "path": "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif",
-        "band": 5,
-    },
-    ("rast_gdpTot_1990_2020_30arcsec", 2015): {
-        "path": "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif",
-        "band": 6,
-    },
-    ("rast_gdpTot_1990_2020_30arcsec", 2020): {
-        "path": "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif",
-        "band": 7,
-    },
-}
+YAML_EXAMPLE = textwrap.dedent(
+    """\
+    Example YAML format:
 
-ZONAL_OPS = ["mean", "max", "min"]
+    workspace:
+        path: "summary_pipeline_workspace"
+
+    vector_zones:
+      hydrosheds_lv6_synth:
+        path: "./data/reference/hydrosheds_lv6_synth.gpkg"
+
+    raster_layers:
+      rast_gdpTot_1990_2020_30arcsec_1990:
+        path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+        band: 1
+
+      rast_gdpTot_1990_2020_30arcsec_1995:
+        path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+        band: 2
+
+      rast_gdpTot_1990_2020_30arcsec_2000:
+        path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
+        band: 3
+
+    ops_stats:
+      - mean
+      - max
+      - min
+    """
+)
 
 
-WORKSPACE_DIR = "./summary_pipeline_workspace"
-os.makedirs(WORKSPACE_DIR, exist_ok=True)
 REPORTING_INTERVAL = 10.0
 
 
@@ -120,6 +117,9 @@ def zonal_stats(raster_path_band_dict, zonal_ops, vector_path):
     Args:
         raster_path_band_dict (dict): dictionary containing 'path' and 'band'
             for the raster to process.
+        zonal_ops (list): list of zonal ops that can be passed to
+            exact_extract defined here:
+            https://isciences.github.io/exactextract/operations.html
         vector_path (str): Path to the vector file containing polygon
             geometries.
 
@@ -155,20 +155,49 @@ def zonal_stats(raster_path_band_dict, zonal_ops, vector_path):
 
 def main():
     """Entry point."""
+    parser = argparse.ArgumentParser(description="Zonal stats pipeline.")
+    parser.add_argument(
+        "config_yaml",
+        type=Path,
+        help="Path to YAML configuration example:\n\n" + YAML_EXAMPLE,
+    )
+    args = parser.parse_args()
+    with args.config_yaml.open("r") as f:
+        config = yaml.safe_load(f)
+
+    required_fields = {
+        "workspace_dir",
+        "vector_zones",
+        "raster_layers",
+        "op_stats",
+    }
+    missing = required_fields - config.keys()
+    if missing:
+        raise ValueError(
+            f'Missing fields {", ".join(sorted(missing))} in {args.config_yaml}'
+        )
+
+    workspace_dir = config["workspace_dir"]
+    os.makedirs(workspace_dir, exists_ok=True)
+
+    analysis_data = config["analysis_data"]
+    zonal_ops = config["zonal_ops"]
+
     start_time = time.time()
+    raster_layers = config["raster_layers"]
     physical_cores = psutil.cpu_count(logical=False)
     task_graph = taskgraph.TaskGraph(
-        WORKSPACE_DIR,
-        n_workers=min(len(ANALYSIS_DATA), physical_cores),
+        workspace_dir,
+        n_workers=min(len(raster_layers), physical_cores),
         reporting_interval=REPORTING_INTERVAL,
     )
     zonal_stats_task_list = []
 
     for vector_id, vector_path in REFERENCE_SUMMARY_VECTOR_PATHS.items():
-        for (raster_id, year), raster_path_band_dict in ANALYSIS_DATA.items():
+        for (raster_id, year), raster_path_band_dict in raster_layers.items():
             stats_task = task_graph.add_task(
                 func=zonal_stats,
-                args=(raster_path_band_dict, ZONAL_OPS, vector_path),
+                args=(raster_path_band_dict, zonal_ops, vector_path),
                 store_result=True,
                 task_name=(
                     f"zonal stats for {raster_id}:"
@@ -187,14 +216,12 @@ def main():
         gdf["fid"] = gdf.index.astype("int32")
         for raster_id, band_idx, stats_task in zonal_stats_task_list:
             stats_df = stats_task.get()
-            rename_map = {
-                op: f"{raster_id}:{band_idx}_{op}" for op in ZONAL_OPS
-            }
+            rename_map = {op: f"{raster_id}_{op}" for op in zonal_ops}
             stats_df.rename(columns=rename_map, inplace=True)
             gdf = gdf.merge(stats_task.get(), on="fid")
         timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
         out_vector_path = os.path.join(
-            WORKSPACE_DIR, f"{vector_id}_synth_zonal_{timestamp}.gpkg"
+            workspace_dir, f"{vector_id}_synth_zonal_{timestamp}.gpkg"
         )
         gdf.to_file(out_vector_path, driver="GPKG")
         print(

--- a/summary_pipeline.py
+++ b/summary_pipeline.py
@@ -101,7 +101,7 @@ def create_progress_logger(update_rate, task_id):
     return _process_logger
 
 
-def zonal_stats(raster_path_band_dict, zonal_ops, vector_path):
+def zonal_stats(raster_path_band_dict, op_stats, vector_path):
     """Calculate zonal statistics for vector file over a given raster.
 
     This function reads polygon geometries from a vector file, assigns a
@@ -113,7 +113,7 @@ def zonal_stats(raster_path_band_dict, zonal_ops, vector_path):
     Args:
         raster_path_band_dict (dict): dictionary containing 'path' and 'band'
             for the raster to process.
-        zonal_ops (list): list of zonal ops that can be passed to
+        op_stats (list): list of zonal ops that can be passed to
             exact_extract defined here:
             https://isciences.github.io/exactextract/operations.html
         vector_path (str): Path to the vector file containing polygon
@@ -122,7 +122,7 @@ def zonal_stats(raster_path_band_dict, zonal_ops, vector_path):
     Returns:
         pandas.DataFrame: DataFrame containing zonal statistics with one row
         per polygon, identified by 'fid' and columns for each calculated
-        statistic named from `ZONAL_OPS`.
+        statistic named from `op_stats`.
     """
     gdf = gpd.read_file(vector_path)
 
@@ -137,7 +137,7 @@ def zonal_stats(raster_path_band_dict, zonal_ops, vector_path):
             band_idx=raster_path_band_dict["band"],
         ),
         vec=gdf,
-        ops=zonal_ops,
+        ops=op_stats,
         include_cols=["fid"],
         output="pandas",
         strategy="raster-sequential",
@@ -203,10 +203,10 @@ def main():
             f'Missing fields {", ".join(sorted(missing))} in {args.config_yaml_path}'
         )
 
-    workspace_dir = pipeline_config["workspace_dir"]
-    os.makedirs(workspace_dir, exists_ok=True)
+    workspace_dir = pipeline_config["workspace_dir"]["path"]
+    os.makedirs(workspace_dir, exist_ok=True)
 
-    zonal_ops = pipeline_config["zonal_ops"]
+    op_stats = pipeline_config["op_stats"]
 
     start_time = time.time()
     raster_layers = pipeline_config["raster_layers"]
@@ -221,10 +221,10 @@ def main():
     vector_zones = pipeline_config["vector_zones"]
     for vector_id, vector_config in vector_zones.items():
         vector_path = vector_config["path"]
-        for (raster_id, year), raster_path_band_dict in raster_layers.items():
+        for raster_id, raster_path_band_dict in raster_layers.items():
             stats_task = task_graph.add_task(
                 func=zonal_stats,
-                args=(raster_path_band_dict, zonal_ops, vector_path),
+                args=(raster_path_band_dict, op_stats, vector_path),
                 store_result=True,
                 task_name=(
                     f"zonal stats for {raster_id}:"
@@ -244,7 +244,7 @@ def main():
             # renames the stat to be the raster id provided in the
             # config file with a _operation at the end so we can
             # differentiate the operation applied to that raster
-            rename_map = {op: f"{raster_id}_{op}" for op in zonal_ops}
+            rename_map = {op: f"{raster_id}_{op}" for op in op_stats}
             stats_df.rename(columns=rename_map, inplace=True)
             gdf = gdf.merge(stats_task.get(), on="fid")
         timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")


### PR DESCRIPTION
This PR fixes issues #3 and #6 by introducing a yaml config file that the user provides to specify the analysis. The an example format of this file is as follows:

`    workspace:
        path: "summary_pipeline_workspace"

    vector_zones:
      hydrosheds_lv6_synth:
        path: "./data/reference/hydrosheds_lv6_synth.gpkg"

    raster_layers:
      rast_gdpTot_1990_2020_30arcsec_1990:
        path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
        band: 1

      rast_gdpTot_1990_2020_30arcsec_1995:
        path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
        band: 2

      rast_gdpTot_1990_2020_30arcsec_2000:
        path: "./data/analysis/Gridded_GDP/rast_gdpTot_1990_2020_30arcsec.tif"
        band: 3

    ops_stats:
      - mean
      - max
      - min
   
Here the user specifies the workspace as the output, then any vector zones or raster layers. The "path" in the vector zones is relative to the config file whereas the workspace is relative to the current working directory. 

This fixes #3 because the user can now specify how they want to name their output field explicitly and they don't need to rely on "band" or "year" or whatever to be appended, the user just names it.

Ops stats are the operations listed at https://isciences.github.io/exactextract/operations.html of which you can have any number.

Then this obviously fixes #6 because this is the yaml file.

I've also updated the Docker/environment.yml file with the new dependencies required to run this feature. I've pre-built and pushed so you can get a new copy with:
`docker pull therealspring/global_ncp-computational-environment:latest` and then you can run with a `docker run -it --rm -v `pwd`:/workspace therealspring/global_ncp-computational-environment:latest /bin/bash`
